### PR TITLE
Revert "Petrux requirements"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ The news article metadata is ~1 GB.
 ```
 virtualenv venv
 source venv/bin/activate
-pip install -r requirements.txt
+pip install lxml==3.3.3
+pip install cchardet==0.3.5
+pip install requests==2.2.1
 ```
 
 You may need to install `libxml2` development packages to install `lxml`:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-argparse==1.2.1
-cchardet==0.3.5
-lxml==3.3.3
-requests==2.2.1
-wsgiref==0.1.2


### PR DESCRIPTION
Reverts deepmind/rc-data#1

It breaks the script unless the entire repository has been cloned. Another wget for requirements.txt is needed.
